### PR TITLE
fix: Ignore cache when in CMS preview

### DIFF
--- a/src/services/Data.php
+++ b/src/services/Data.php
@@ -93,7 +93,10 @@ class Data extends Component
             }
         }
 
-        if ($this->settings->enableCache && method_exists($transformer, 'getCacheKey')) {
+        $request = Craft::$app->getRequest();
+        $ignoreCache = $request->getIsLivePreview() || $request->getToken();
+
+        if ($this->settings->enableCache && !$ignoreCache && method_exists($transformer, 'getCacheKey')) {
             $cacheKey = $transformer->getCacheKey($element);
             $cached = Craft::$app->getCache()->get($cacheKey) ?: null;
 


### PR DESCRIPTION
Craft CMS automatically appends the preview ?token= query param to all element URLs. This could result in the cache being poisoned by preview URLs.

Steps to reproduce:
- Have a transformer that provides getCacheKey and retrieves an
  element URL
- Ensure that the cache is empty, e.g. run ./craft clear-caches/all
- Open a preview in the CMS that triggers the transformer
- Open the page without preview token in an incognito tab
- The URL retrieved by the transformer now has an unexpected preview
  token

Preview tokens should NOT be cached as they disable page caching and may expose content to public visitors that they should not have seen.

This commit adapts the behavior of the {% cache %} twig tag:

https://github.com/craftcms/cms/blob/c21a32ea8f9f3ded626e07c36c85ab0da2379b22/src/web/twig/nodes/CacheNode.php#L48